### PR TITLE
feat(external-secrets): migrate platform helm charts to external secrets

### DIFF
--- a/charts/platform-secrets/Chart.yaml
+++ b/charts/platform-secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: platform-secrets
 description: A Helm chart for platform-secrets service
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.0.0
 dependencies:
   - name: k8s-resources

--- a/charts/platform-secrets/templates/externalSecret.yaml
+++ b/charts/platform-secrets/templates/externalSecret.yaml
@@ -1,0 +1,30 @@
+{{- range .Values.externalSecrets }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .name | quote }}
+  labels: {{ include "platformAdmin.labels.standard" $ | nindent 4 }}
+    service: platform-admin
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: {{ .secretStoreName | default "default-secret-store" | quote }}
+    kind: {{ .secretStoreKind | default "ClusterSecretStore" }}
+  target:
+    name: {{ .name | quote }}
+    creationPolicy: "Owner"
+    template:
+      metadata:
+        labels: {{ include "platformAdmin.labels.standard" $ | nindent 10 }}
+          service: platform-admin
+        annotations:
+          reloader.stakater.com/match: "true"
+  data:
+    {{- range $key, $ref := .data }}
+    - secretKey: {{ $key | quote }} #target K8s secret key
+      remoteRef:
+        key: {{ $ref.key | quote }} #Remote secret mount key, e.g.. vault
+        property: {{ $ref.property | quote }} #Remote secret key, e.g.. platform-admin-dsn
+    {{- end }}
+{{- end }}

--- a/charts/platform-secrets/templates/externalSecret.yaml
+++ b/charts/platform-secrets/templates/externalSecret.yaml
@@ -4,8 +4,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .name | quote }}
-  labels: {{ include "platformAdmin.labels.standard" $ | nindent 4 }}
-    service: platform-admin
+  labels: {{ include "platformSecrets.labels.standard" $ | nindent 4 }}
+    service: platform-secrets
 spec:
   refreshInterval: "15s"
   secretStoreRef:
@@ -16,8 +16,8 @@ spec:
     creationPolicy: "Owner"
     template:
       metadata:
-        labels: {{ include "platformAdmin.labels.standard" $ | nindent 10 }}
-          service: platform-admin
+        labels: {{ include "platformSecrets.labels.standard" $ | nindent 10 }}
+          service: platform-secrets
         annotations:
           reloader.stakater.com/match: "true"
   data:

--- a/charts/platform-secrets/values.yaml
+++ b/charts/platform-secrets/values.yaml
@@ -32,6 +32,18 @@ service:
 
 secrets: []
 
+externalSecrets:
+  - name: platform-admin-secret
+    secretStoreName: vault-backend
+    secretStoreKind: ClusterSecretStore
+    data:
+      DATABASE_URL:
+        key: kv-v2/platform
+        property: DATABASE_URL
+      API_KEY:
+        key: kv-v2/platform
+        property: API_KEY
+
 sentry:
   appName: platform-secrets
   sampleRate: 0.01

--- a/charts/platform-secrets/values.yaml
+++ b/charts/platform-secrets/values.yaml
@@ -32,17 +32,17 @@ service:
 
 secrets: []
 
-externalSecrets:
-  - name: platform-admin-secret
-    secretStoreName: vault-backend
-    secretStoreKind: ClusterSecretStore
-    data:
-      DATABASE_URL:
-        key: kv-v2/platform
-        property: DATABASE_URL
-      API_KEY:
-        key: kv-v2/platform
-        property: API_KEY
+externalSecrets: []
+  # - name: platform-admin-secret
+  #   secretStoreName: vault-backend
+  #   secretStoreKind: ClusterSecretStore
+  #   data:
+  #     DATABASE_URL:
+  #       key: kv-v2/platform
+  #       property: DATABASE_URL
+  #     API_KEY:
+  #       key: kv-v2/platform
+  #       property: API_KEY
 
 sentry:
   appName: platform-secrets


### PR DESCRIPTION
This PR migrates the platform helm chart to use external secrets and bumps the chart minor version.